### PR TITLE
Fix bug in addnstr

### DIFF
--- a/source/nice/curses.d
+++ b/source/nice/curses.d
@@ -485,6 +485,7 @@ final class Window
             import std.range;
             import std.uni;
 
+            scope(exit) setAttr(Attr.normal);
             setAttr(attr);
             wchar_t[] chars = [];
             chars.reserve(str.walkLength);


### PR DESCRIPTION
When addnstr was used with an attribute, it would effect
all later output.
This is because it changes the default attribute for the
window in order to efficiently write the entire string
with the attribute set, but it does not set the default
attribute back after having written the string.

This adds a scope statement that will set the attribute
to Attr.normal after finishing the write.